### PR TITLE
Add Apache License Boilerplate to Pedant repositories

### DIFF
--- a/chef-pedant
+++ b/chef-pedant
@@ -1,5 +1,20 @@
 #!/usr/bin/env ruby
 
+# Copyright: Copyright (c) 2012 Opscode, Inc.
+# License: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 require 'bundler/setup' # so we don't need to type 'bundle exec' to run it
 
 require 'rspec/core'

--- a/open-source-config.rb
+++ b/open-source-config.rb
@@ -1,3 +1,18 @@
+# Copyright: Copyright (c) 2012 Opscode, Inc.
+# License: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # This annotated Pedant configuration file details the various
 # configuration settings available to you.  It is separate from the
 # actual Pedant::Config class because not all settings have sane


### PR DESCRIPTION
Does what it says on the label.
