### PR TITLE
OC-4907 Clients and Users should accept public_key

### DIFF
--- a/lib/pedant/rspec/user_util.rb
+++ b/lib/pedant/rspec/user_util.rb
@@ -111,6 +111,7 @@ module Pedant
 
             should_respond_with 200, 'and update the user' do
               parsed_response['public_key'].should_not be_nil
+              parsed_response.member?('private_key').should be_false # Make sure private_key is not returned at all
 
               # Now verify that you can retrieve it again
               persisted_resource_response.should look_like updated_response

--- a/spec/api/clients/open_source_complete_endpoint_spec.rb
+++ b/spec/api/clients/open_source_complete_endpoint_spec.rb
@@ -147,6 +147,7 @@ describe "Open Source Client API endpoint", :platform => :open_source, :clients 
 
           should_respond_with 201, 'and update the user' do
             parsed_response['public_key'].should_not be_nil
+            parsed_response.member?('private_key').should be_false # Make sure private_key is not returned at all
 
             # Now verify that you can retrieve it again
             persisted_resource_response.should look_like updated_response
@@ -420,6 +421,7 @@ describe "Open Source Client API endpoint", :platform => :open_source, :clients 
 
           should_respond_with 200, 'and update the user' do
             parsed_response['public_key'].should_not be_nil
+            parsed_response.member?('private_key').should be_false # Make sure private_key is not returned at all
 
             # Now verify that you can retrieve it again
             persisted_resource_response.should look_like updated_response

--- a/spec/api/users_spec.rb
+++ b/spec/api/users_spec.rb
@@ -136,6 +136,7 @@ describe "Open Source /users endpoint", :users => true, :platform => :open_sourc
 
           should_respond_with 201, 'and update the user' do
             parsed_response['public_key'].should_not be_nil
+            parsed_response.member?('private_key').should be_false # Make sure private_key is not returned at all
 
             # Now verify that you can retrieve it again
             persisted_resource_response.should look_like updated_response


### PR DESCRIPTION
- Added public_key tests for create users, create clients, and update clients
- I did not do a full conversion for clients tests, but this is something to seriously consider in order to take advantage of the new validation macros

See:
- https://github.com/opscode/chef_wm/pull/39
- https://github.com/opscode/chef_objects/pull/26
- https://github.com/opscode/chef-pedant/pull/8
