### PR TITLE
Remove json_class from committed sandbox response JSON

### DIFF
--- a/spec/api/sandboxes/complete_endpoint_spec.rb
+++ b/spec/api/sandboxes/complete_endpoint_spec.rb
@@ -263,9 +263,7 @@ describe "Sandboxes API Endpoint", :sandboxes do
           "guid"        => sandbox_id,
           "name"        => sandbox_id,
           "checksums"   => checksums,
-          "create_time" => timestamp_regexp,
-          "json_class"  => "Chef::Sandbox",
-          "chef_type"   => "sandbox"
+          "create_time" => timestamp_regexp
         }
       end
 


### PR DESCRIPTION
The Chef::Sandbox class has been removed from Chef. Due to the
auto-inflation of objects when parsing JSON, Chef will crash if it
receives a response for the server with an unknown json_class field.

The inflated sandbox object is not used by Chef10 or Chef11 client
code. So it should be safe to simply remove the json_class field.

In an ideal world, we'd modify the API to return 204 or error status
code when responding to commit sandbox requests. However, Chef10
clients crash on empty body responses.
