### PR TITLE
Make Pedant Tests Pass

### DIFF
--- a/spec/api/cookbooks/delete_spec.rb
+++ b/spec/api/cookbooks/delete_spec.rb
@@ -105,7 +105,9 @@ describe "Cookbooks API endpoint", :cookbooks do
         before(:each) { setup_cookbooks(cookbooks) }
         after(:each)  { remove_cookbooks(cookbooks) }
 
-        it "should cleanup unused checksum data in s3/bookshelf", :pending => ruby?, :focus => true do
+        # The Ruby endpoint doesn't delete data on demand like the
+        # Erlang version does (that'd be a separate purge operation)
+        it "should cleanup unused checksum data in s3/bookshelf", :pending => ruby? do
           verify_checksum_cleanup(:recipes) do
             response.should look_like(:status => 200)
           end


### PR DESCRIPTION
Fixes last remaining test failures for OPC mixed Ruby / Erlang servers.
