### PR TITLE
CHEF-3686: Standardize timestamps and unique names in Pedant tests

### DIFF
--- a/lib/pedant.rb
+++ b/lib/pedant.rb
@@ -46,6 +46,7 @@ module Pedant
     configure_logging
     puts "Creating platform..."
     create_platform
+    puts "Starting Pedant Run: #{config.pedant_platform.pedant_run_timestamp}"
     configure_rspec
   end
 
@@ -69,7 +70,7 @@ module Pedant
     config.pedant_platform = platform_class.new(config.chef_server,
                                                 config.superuser_key,
                                                 config.superuser_name)
-    end
+  end
 
   def self.configure_rspec
     ::RSpec.configure do |c|

--- a/lib/pedant/platform.rb
+++ b/lib/pedant/platform.rb
@@ -29,6 +29,8 @@ module Pedant
       @server = server
       @superuser_key_file = superuser_key_file
       @superuser = Pedant::Requestor.new(superuser_name, superuser_key_file, platform: self)
+      self.pedant_run_timestamp # Cache the global timestamp at initialization
+      self
     end
 
     def api_url(url_path)
@@ -133,6 +135,21 @@ yap6MUYSjPOa7eCrhg2zFZiqO6VLEogPc1nsjb9Zl2UWLLYyCVz=
 -----END RSA PRIVATE KEY-----"
 
       Pedant::Client.new(name, bogus_key, platform: self, preexisting: false, bogus: true)
+    end
+
+    # Normalize timestamps used in Pedant
+    # In tests, you can access this with:
+    # let(:timestamp) { platform.now }
+    def timestamp
+      Time.now.utc
+    end
+
+    alias now timestamp
+
+    # Global timestamp marking the beginning of the run
+    # Use this for things like generating unique names
+    def pedant_run_timestamp
+      @_pedant_run_timestamp ||= self.timestamp
     end
   end
 end

--- a/lib/pedant/rspec/common.rb
+++ b/lib/pedant/rspec/common.rb
@@ -305,22 +305,23 @@ module Pedant
         end
         let(:open_source?) { self.class.open_source? }
 
-        # Append an all-but-certain-to-be-unique suffix to a given string.
-        # Useful for generating names for testing entities that will not
-        # conflict with existing ones (of concern mainly for Open Source
-        # Chef Servers, as tests cannot be sandboxed to a testing
-        # organization.)
+        # Timestamp suffixes
+        # Suffix unique between runs. Timestamp is generated once per pedant run
+        let(:pedant_suffix) { suffix_for_names.(platform.pedant_run_timestamp) }
+
+        # Suffix unique to the example, bound to a let().
+        let(:unique_suffix) { suffix_for_names.(platform.timestamp) }
+        let(:suffix_for_names) {->(t) { "#{t.to_i}-#{t.nsec}-#{Process.pid}" } }
+
+        # The suffix is unique for Pedant runs, but not within each pedant run.
+        # For a unique timestamp within a Pedant run, use platform.timestamp
+        # or unique_suffix
         #
-        # Also prefixes the generated string with "pedant_" to ensure
-        # that test data is always easy to spot, just to be extra
-        # paranoid.
-        #
-        # Note that the suffix is currently time-based, so if you intend to
-        # re-use this name in multiple places in a test, you must set it in
-        # a let block!
+        # - Prefixes "pedant_" for the name
+        # - Appends a suffix unique for the entire Pedant run
+        # - Useful for things like names for roles, nodes, etc.
         def unique_name(name)
-          t = Time.now
-          "pedant_#{name}_#{t.to_i}#{t.nsec}#{Process.pid}"
+          "pedant_#{name}_#{pedant_suffix}"
         end
 
         # Helper method for helper methods; useful for ensuring that

--- a/lib/pedant/rspec/cookbook_util.rb
+++ b/lib/pedant/rspec/cookbook_util.rb
@@ -363,7 +363,7 @@ module Pedant
           if spec.is_a?(String)
             {
               :name => spec,
-              :content => Pedant::Utility.with_unique_suffix("pedant-recipe-content-")
+              :content => "pedant-recipe-content-#{unique_suffix}"
             }
           else
             spec

--- a/lib/pedant/rspec/search_util.rb
+++ b/lib/pedant/rspec/search_util.rb
@@ -23,6 +23,10 @@ module Pedant
       extend ::RSpec::Core::SharedContext
       extend Pedant::Concern
 
+      included do
+        let(:a_search_item) { ->(x) { "pedant-search-target-#{x}-#{unique_suffix}" } }
+      end
+
       module ClassMethods
 
         # Given a cookbook name and a version string (e.g., "1.0.0"), generate the legal
@@ -701,25 +705,21 @@ module Pedant
       if Pedant::Config.search_server
 
         let(:requestor) { admin_user }
-        let(:item_name){
-          t = Time.now
-          # A string prefix, followed by the number of seconds from the
-          # epoch, followed by the number of nanoseconds from the last
-          # fractional second from the epoch, followed by the pid.  This
-          # ought to be suitably unique.  Grabbing a UUID gem just for
-          # this seems a bit overblown.
-          "pedant-search-target-#{t.to_i}-#{t.nsec}-#{Process.pid}"
-        }
-
+        # A string prefix, followed by the number of seconds from the
+        # epoch, followed by the number of nanoseconds from the last
+        # fractional second from the epoch, followed by the pid.  This
+        # ought to be suitably unique.  Grabbing a UUID gem just for
+        # this seems a bit overblown.
+        let(:item_name) { a_search_item.('resource') }
         let(:deletion_identifier) { item_name } #default to item_name; override this for data bag items
 
         after :each do
           delete_chef_object(container, requestor, item_name)
         end
 
-        let (:index_name) { raise 'Must specify an :index_name! (e.g., a search index like "node", "role", or "data")' }
-        let (:container) { raise 'Must specify a :container! (e.g., "nodes", "roles", "data", etc.' }
-        let (:item) { raise 'Must specify an :item (JSON string or Hash to insert)'}
+        let(:index_name) { raise 'Must specify an :index_name! (e.g., a search index like "node", "role", or "data")' }
+        let(:container) { raise 'Must specify a :container! (e.g., "nodes", "roles", "data", etc.' }
+        let(:item) { raise 'Must specify an :item (JSON string or Hash to insert)'}
 
         it "deletes an object from Solr when deleting from the system as a whole" do
           # Assert that there is no item of the given type with the given name in the search index

--- a/lib/pedant/utility.rb
+++ b/lib/pedant/utility.rb
@@ -32,8 +32,15 @@ module Pedant
     # Generates a a string with the given prefix and a unique suffix
     # incorporating seconds (and nanoseconds) from the epoch, along
     # with the current process id
+    #
+    # DEPRECATED: Do not use this within the spec. Use pedant_suffix or unique_suffix instead
+    #
+    # TODO: This should be refactored to merge with the unique_suffix and
+    # platform.pedant_run_timestamp. However, to access this, this module needs
+    # to know the platform. Not sure how to organize this yet.
+    #
     def self.with_unique_suffix(prefix)
-      t = Time.now
+      t = Time.now.utc
       "#{prefix}-#{t.to_i}-#{t.nsec}-#{Process.pid}"
     end
 

--- a/spec/api/authenticate_user_spec.rb
+++ b/spec/api/authenticate_user_spec.rb
@@ -81,7 +81,7 @@ describe "Open source /authenticate_users endpoint", :users => true, :platform =
     end
 
     context 'with a non-existing user' do
-      let(:no_such_user) { Pedant::Utility.with_unique_suffix("no-such-user-") }
+      let(:no_such_user) { "no-such-user-#{unique_suffix}" }
       let(:expected_response) { ok_full_response }
       let(:success_message) do
         {

--- a/spec/api/cookbooks/delete_spec.rb
+++ b/spec/api/cookbooks/delete_spec.rb
@@ -83,7 +83,7 @@ describe "Cookbooks API endpoint", :cookbooks do
 
       context "when deleting existent version of an existing cookbook", :smoke do
         let(:recipe_name) { "test_recipe" }
-        let(:recipe_content) { Pedant::Utility.with_unique_suffix("hello") }
+        let(:recipe_content) { "hello-#{unique_suffix}" }
         let(:recipe_spec) do
             {
               :name => recipe_name,

--- a/spec/api/cookbooks/read_spec.rb
+++ b/spec/api/cookbooks/read_spec.rb
@@ -244,7 +244,7 @@ describe "Cookbooks API endpoint", :cookbooks do
     let(:cookbook_name) { "the_cookbook_name" }
     let(:cookbook_version) { "1.2.3" }
     let(:recipe_name) { "test_recipe" }
-    let(:recipe_content) { Pedant::Utility.with_unique_suffix("hello") }
+    let(:recipe_content) { "hello-#{unique_suffix}" }
     let(:recipe_spec) do
         {
           :name => recipe_name,

--- a/spec/api/sandboxes/complete_endpoint_spec.rb
+++ b/spec/api/sandboxes/complete_endpoint_spec.rb
@@ -15,7 +15,7 @@
 
 require 'pedant/rspec/cookbook_util'
 
-describe "Sandboxes API Endpoint" do
+describe "Sandboxes API Endpoint", :sandboxes do
   include Pedant::RSpec::CookbookUtil
 
   def self.ruby?
@@ -268,7 +268,7 @@ describe "Sandboxes API Endpoint" do
       end
 
       # YYYY-MM-DDT00:00:00+00:00, but we'll constraint it to at least today's date
-      let(:timestamp_regexp) { Regexp.new "#{Time.new.strftime('%Y-%m-%d')}T\\d\\d:\\d\\d:\\d\\d\\+\\d\\d:\\d\\d" }
+      let(:timestamp_regexp) { Regexp.new "#{platform.now.strftime('%Y-%m-%d')}T\\d\\d:\\d\\d:\\d\\d\\+\\d\\d:\\d\\d" }
 
       it 'should respond with 200 OK', :smoke do
         # Upload and check files

--- a/spec/api/search/search_spec.rb
+++ b/spec/api/search/search_spec.rb
@@ -483,28 +483,19 @@ describe 'Search API endpoint', :search do
       end
 
     context "many results (roles)" do
+      # TODO: Refactor this to shared() ?
       ROLE_STASH = Hash.new
-      let(:role_names) {
-        ROLE_STASH[:role_names] ||= 10.times.map { |i|
-          t = Time.now
-          "pedant-search-target-#{i}-#{t.to_i}-#{t.nsec}-#{Process.pid}"
-        }
-      }
+      let(:role_names) { ROLE_STASH[:role_names] ||= 10.times.map(&a_search_item) }
+      let(:description) { ROLE_STASH[:description] ||= "partial-search-role-description-#{rand(10000).to_s}" }
 
-      let(:description) {
-        ROLE_STASH[:description] ||= "partial-search-role-description-#{rand(10000).to_s}"
-      }
-
-      let(:roles) {
-        i = 0
-        role_names.map do |name|
-          i += 1
+      let(:roles) do
+        role_names.each_with_index.map do |name, i|
           new_role(name, {
                      :override_attributes => {'top' => {'mid' => {'bottom' => i}}},
                      :description => description
                    })
         end
-      }
+      end
 
       before(:all) do
         roles.each do |r|
@@ -535,7 +526,7 @@ describe 'Search API endpoint', :search do
                                         :body => {'total' => 10}})
             got = parse(response)['rows']
             got_digits = got.map { |o| o['data']['goal'] }.sort
-            got_digits.should == (1..10).to_a
+            got_digits.should == (0..9).to_a
           end # response
 
         end
@@ -560,12 +551,7 @@ describe 'Search API endpoint', :search do
         }
       }
 
-      let(:node_name) {
-        STASH[:node_name] ||= begin
-                                t = Time.now
-                                "pedant-search-target-#{t.to_i}-#{t.nsec}-#{Process.pid}"
-                              end
-      }
+      let(:node_name) { STASH[:node_name] ||= a_search_item.('node') }
 
       let(:a_node) {
         n = new_node(node_name)


### PR DESCRIPTION
- Use Time.now.utc
  - Added timestamp helper
  - Added pedant_run_timestamp (for the entire pedant run)
  - Added various suffix helpers
  - Deprecated Pedant::Utility.with_unique_suffix for pedant tests
  - Refined some tests using unique_suffix
