### PR TITLE
Fix dep solving with constraints in environment

### DIFF
--- a/spec/api/depsolver_spec.rb
+++ b/spec/api/depsolver_spec.rb
@@ -261,8 +261,10 @@ describe "Depsolver API endpoint", :depsolver do
       it "returns 412 with an existing cookbook filtered out by environment" do
         payload = "{\"run_list\":[\"#{cookbook_name}\"]}"
 
-        error_message = "{\"message\":\"Run list contains invalid items: no such cookbook #{cookbook_name}.\","\
-                        "\"non_existent_cookbooks\":[\"#{cookbook_name}\"],\"cookbooks_with_no_versions\":[]}"
+        error_message = ("{\"message\":\"Run list contains invalid items: " +
+                         "no versions match the constraints on cookbook #{cookbook_name}.\"," +
+                         "\"non_existent_cookbooks\":[]," +
+                         "\"cookbooks_with_no_versions\":[\"#{cookbook_name}\"]}")
         error_hash = {
           "message" => "Unable to satisfy constraints on cookbook #{cookbook_name}, which does not exist.",
           "non_existent_cookbooks" => [cookbook_name],


### PR DESCRIPTION
This PR addresses CHEF-3699 in which we learn that depsolving was
broken when using an environment containing any form of cookbook
version constraint.

The patches are lightly tested at this time, but given the previous
behavior, I'd like to get this fix into a build sooner rather than
later and then come back to significantly ramp up the test coverage
around depsolving.

The patches in chef_objects result in the environment constraints
being applied as a pre-filter before calling the solver. The downside
of this approach is that the solver cannot give useful error messages
when the root cause is that cookbooks have been filtered out by the
environment.

http://tickets.opscode.com/browse/CHEF-3699
