### PR TITLE
Add support for an  internal server address

### DIFF
--- a/lib/pedant.rb
+++ b/lib/pedant.rb
@@ -68,6 +68,7 @@ module Pedant
     raise "Must specify an implementation class of Pedant::Platform!  Use the `platform_class` key in your Pedant config file" unless platform_class
 
     config.pedant_platform = platform_class.new(config.chef_server,
+                                                config.internal_server,
                                                 config.superuser_key,
                                                 config.superuser_name)
   end

--- a/lib/pedant/opensource/platform.rb
+++ b/lib/pedant/opensource/platform.rb
@@ -20,15 +20,19 @@ module Pedant
 
     attr_reader :admin_requestors, :normal_requestors, :webui, :webui_key_file
 
-    def initialize(server, superuser_key_file, super_user_name='chef-webui')
+    def initialize(server, internal_server, superuser_key_file, super_user_name='chef-webui')
       @webui_key_file = Pedant::Config.webui_key || (fail "Missing webui_key in Pedant config.")
       @webui = Pedant::Requestor.new('chef-webui', superuser_key_file, platform: self)
-      super(server, superuser_key_file, super_user_name)
+      super(server, internal_server, superuser_key_file, super_user_name)
     end
 
     def api_url(path_fragment = '')
       slash = path_fragment.start_with?('/') ? '' : '/'
       "#{@server}#{slash}#{path_fragment}"
+    end
+    
+    def internal_api_url(path_fragment = '') 
+      api_url(path_fragment)
     end
 
     def setup(requestors=Pedant::Config.requestors)

--- a/lib/pedant/platform.rb
+++ b/lib/pedant/platform.rb
@@ -19,14 +19,15 @@ module Pedant
   class Platform
     include Pedant::Request
 
-    attr_reader :server, :superuser, :superuser_key_file
+    attr_reader :server, :internal_server, :superuser, :superuser_key_file
 
     # Create a Platform object for a given server (specified by
     # protocol, hostname, and port ONLY).  You must supply the
     # superuser's key file, which can either be the path to the file,
     # or the contents of the file.
-    def initialize(server, superuser_key_file, superuser_name)
+    def initialize(server, internal_server, superuser_key_file, superuser_name)
       @server = server
+      @internal_server = internal_server
       @superuser_key_file = superuser_key_file
       @superuser = Pedant::Requestor.new(superuser_name, superuser_key_file, platform: self)
       self.pedant_run_timestamp # Cache the global timestamp at initialization
@@ -37,6 +38,10 @@ module Pedant
       raise "Must override with an appropriate url generation method!"
     end
 
+    def internal_api_url(url_path)
+      raise "Must override with an appropriate private url generation method!"
+    end
+    
     def setup
       raise "Must override with an appropriate setup method!"
     end

--- a/lib/pedant/rspec/common.rb
+++ b/lib/pedant/rspec/common.rb
@@ -433,6 +433,12 @@ module Pedant
           platform.api_url(path_fragment)
         end
 
+        # As api_url, but reference the internal server address.  Currently
+        # only applicable for multi-tentant platforms.
+        def internal_api_url(path_fragment)
+          platform.internal_api_url(path_fragment)
+        end
+
         # Given a response object, verify the HTTP status is in the
         # 200-ish success range and raise an error if it is not. This
         # is intended to be used in helper/util modules where we want


### PR DESCRIPTION
- Supports testing in against internal load balancers and endpoints
  in multitenant scenarios
- Add configuration support for internal_server.
- Add internal_api_url helper method. For single tenant this will
- behave the same as api_url.
