### PR TITLE
Remove chef dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,8 @@
 PATH
   remote: .
   specs:
-    chef-pedant (0.0.11)
+    chef-pedant (1.0.0)
       activesupport (~> 3.2.8)
-      chef (~> 10.12.0)
       erubis (~> 2.7.0)
       mixlib-authentication (~> 1.3.0)
       mixlib-config (~> 1.1.2)
@@ -17,59 +16,21 @@ PATH
 GEM
   remote: http://rubygems.org/
   specs:
-    activesupport (3.2.9)
+    activesupport (3.2.11)
       i18n (~> 0.6)
       multi_json (~> 1.0)
     builder (3.1.4)
-    bunny (0.8.0)
-    chef (10.12.0)
-      bunny (>= 0.6.0)
-      erubis
-      highline (>= 1.6.9)
-      json (>= 1.4.4, <= 1.6.1)
-      mixlib-authentication (>= 1.1.0)
-      mixlib-cli (>= 1.1.0)
-      mixlib-config (>= 1.1.2)
-      mixlib-log (>= 1.3.0)
-      mixlib-shellout
-      moneta
-      net-ssh (~> 2.2.2)
-      net-ssh-multi (~> 1.1.0)
-      ohai (>= 0.6.0)
-      rest-client (>= 1.0.4, < 1.7.0)
-      treetop (~> 1.4.9)
-      uuidtools
-      yajl-ruby (~> 1.1)
     diff-lcs (1.1.3)
     erubis (2.7.0)
-    highline (1.6.15)
     i18n (0.6.1)
-    ipaddress (0.8.0)
-    json (1.6.1)
     mime-types (1.19)
     mixlib-authentication (1.3.0)
       mixlib-log
-    mixlib-cli (1.2.2)
     mixlib-config (1.1.2)
     mixlib-log (1.4.1)
     mixlib-shellout (1.1.0)
-    moneta (0.6.0)
     multi_json (1.5.0)
     net-http-spy (0.2.1)
-    net-ssh (2.2.2)
-    net-ssh-gateway (1.1.0)
-      net-ssh (>= 1.99.1)
-    net-ssh-multi (1.1)
-      net-ssh (>= 2.1.4)
-      net-ssh-gateway (>= 0.99.0)
-    ohai (6.14.0)
-      ipaddress
-      mixlib-cli
-      mixlib-config
-      mixlib-log
-      systemu
-      yajl-ruby
-    polyglot (0.3.3)
     rest-client (1.6.7)
       mime-types (>= 1.16)
     rspec (2.11.0)
@@ -82,16 +43,10 @@ GEM
     rspec-mocks (2.11.3)
     rspec-rerun (0.1.1)
       rspec (>= 2.11.0)
-    rspec_junit_formatter (0.1.4)
+    rspec_junit_formatter (0.1.5)
       builder
       rspec (~> 2.0)
       rspec-core (!= 2.12.0)
-    systemu (2.5.2)
-    treetop (1.4.12)
-      polyglot
-      polyglot (>= 0.3.1)
-    uuidtools (2.1.3)
-    yajl-ruby (1.1.0)
 
 PLATFORMS
   ruby

--- a/chef-pedant.gemspec
+++ b/chef-pedant.gemspec
@@ -21,6 +21,5 @@ Gem::Specification.new do |s|
   s.add_dependency('rspec_junit_formatter', '~> 0.1.1')
   s.add_dependency('net-http-spy', '~> 0.2.1')
   s.add_dependency('erubis', '~> 2.7.0')
-  s.add_dependency('chef', '~> 10.12.0') # Just to get 'knife' for some tests
   s.add_dependency('rspec-rerun', '= 0.1.1')
 end

--- a/lib/pedant/rspec/knife_util.rb
+++ b/lib/pedant/rspec/knife_util.rb
@@ -73,7 +73,17 @@ module Pedant
         # Convenience method for creating a Mixlib::ShellOut representation
         # of a knife command in our test repository
         def shell_out(command_line)
-          Mixlib::ShellOut.new(command_line, {'cwd' => cwd})
+          # All the environment variable munging is so Bundler doesn't
+          # poison things, since we don't include a Chef gem
+          Mixlib::ShellOut.new(command_line, {
+                                 'cwd' => cwd,
+                                 'env' => {
+                                   'BUNDLE_GEMFILE' => nil,
+                                   'BUNDLE_BIN_PATH' => nil,
+                                   'GEM_PATH' => nil,
+                                   'GEM_HOME' => nil,
+                                   'RUBYOPT' => nil
+                                 }})
         end
 
         # Convenience method for actually running a knife command in our

--- a/spec/api/knife/nodes/run_list_spec.rb
+++ b/spec/api/knife/nodes/run_list_spec.rb
@@ -78,9 +78,7 @@ describe 'knife', knife: true, pending: !open_source? do
               knife "node run_list add #{node_name} app,web -c #{knife_config}"
 
               # Adds run_list item
-              # TODO: For some reason, the run list is wrapped with [], but when we use
-              # `knife node run_list add` it is not
-              should have_outcome :status => 0, :stdout => /run_list:\s+\[recipe\[web\]\]/
+              should have_outcome :status => 0, :stdout => /run_list:\s+recipe\[web\]/
             end
           end
         end


### PR DESCRIPTION
This allows us to pick up the 'knife' executable from the PATH, which
ensures that we can test a client that matches the given version of
the server.

Added some environment tweaks to the shelled-out commands to ensure
that Bundler doesn't poison those commands (knife would fail because
chef couldn't be found in the bundle)

One of our knife tests was slightly tweaked to reflect slightly
different behavior on newer knife versions.
