### PR TITLE
Harmonize cookbook responses between Ruby / Erlang

### DIFF
--- a/spec/api/cookbooks/create_spec.rb
+++ b/spec/api/cookbooks/create_spec.rb
@@ -245,15 +245,20 @@ describe "Cookbooks API endpoint", :cookbooks do
         respects_maximum_payload_size
       end
 
-      it "allows creation of a minimal cookbook with no data" do
-        payload = minimal_cookbook(cookbook_name, cookbook_version)
+      it "allows creation of a minimal cookbook with no data", :focus do
+
+        # Since PUT returns the same thing it was given, we'll just
+        # define the input in terms of the response, since we use that
+        # elsewhere in the test suite.
+        payload = retrieved_cookbook(cookbook_name, cookbook_version)
+
         put(api_url("/cookbooks/#{cookbook_name}/#{cookbook_version}"),
             admin_user,
             :payload => payload) do |response|
           response.
             should look_like({
                                :status => ruby? ? 200 : 201,
-                               :body => minimal_response(cookbook_name, cookbook_version)
+                               :body => payload
                              })
         end
       end # it allows creation of a minimal cookbook with no data
@@ -309,7 +314,7 @@ describe "Cookbooks API endpoint", :cookbooks do
         admin_user) do |response|
         response.should look_like({
                                    :status => 200,
-                                   :body_exact => payload
+                                   :body_exact => retrieved_cookbook(cookbook_name, cookbook_version1)
                                   })
       end
 
@@ -317,7 +322,7 @@ describe "Cookbooks API endpoint", :cookbooks do
         admin_user) do |response|
         response.should look_like({
                                    :status => 200,
-                                   :body_exact => payload2
+                                   :body_exact => retrieved_cookbook(cookbook_name, cookbook_version2)
                                   })
       end
     end # it allows us to create 2 versions of the same cookbook

--- a/spec/api/depsolver_spec.rb
+++ b/spec/api/depsolver_spec.rb
@@ -501,13 +501,24 @@ describe "Depsolver API endpoint", :depsolver do
       }
 
       it "returns 200 with a minimal good cookbook", :smoke do
+
+        cb = retrieved_cookbook(cookbook_name, cookbook_version)
+
+        # We filter out some additional metadata fields for the depsolver endpoint
+        unless(ruby?)
+          meta = cb["metadata"]
+          meta.delete("attributes")
+          meta.delete("long_description")
+          cb["metadata"] = meta
+        end
+
         post(api_url("/environments/#{env}/cookbook_versions"), normal_user,
-            :payload => payload) do |response|
+             :payload => payload) do |response|
           response.should look_like({
-                                     :status => 200,
-                                     :body_exact => {
-                                         cookbook_name => minimal_cookbook(cookbook_name, cookbook_version)
-                                     }
+                                      :status => 200,
+                                      :body_exact => {
+                                        cookbook_name => cb
+                                      }
                                     })
         end
       end


### PR DESCRIPTION
We had a few helpers ('minimal_cookbook', 'minimal_response',
'retrieved_cookbook') that returned "minimal" versions of a cookbook…
those have now been merged together into a single 'retrieved_cookbook'
method that respects the differences between Ruby and Erlang
endpoints.  This new method is written to make it more clear what the
exact differences between the implementations are.

Tests now all use this helper.  Since the depsolver endpoint is unique
(in that the Erlang implementation removes some additional metadata
fields), I've just removed those fields in the test itself, since it's
only used once.

Remove make_minimal_cookbook helper, too, since it wasn't used.
