### PR TITLE
Update test to ignore order in list of recipes.

### DIFF
--- a/spec/api/environments/recipes_spec.rb
+++ b/spec/api/environments/recipes_spec.rb
@@ -141,7 +141,7 @@ describe "/environments/ENVIRONMENT/recipes API endpoint", :environments do
         it 'retrieves appropriate recipes' do
           get(api_url("/environments/#{env}/recipes"), admin_user) do |response|
             response.should have_status_code 200
-            parse(response).should eq expected_recipes
+            parse(response).should =~ expected_recipes
           end
         end
       end


### PR DESCRIPTION
OHC pedant tests pass in pre-prod with this fix.

@sdelano looks like you had a similar change before and missed this one. Please take a look.
