### PR TITLE
Add chef dependency (for knife)

### DIFF
--- a/chef-pedant.gemspec
+++ b/chef-pedant.gemspec
@@ -22,4 +22,5 @@ Gem::Specification.new do |s|
   s.add_dependency('net-http-spy', '~> 0.2.1')
   s.add_dependency('erubis', '~> 2.7.0')
   s.add_dependency('rspec-rerun', '= 0.1.1')
+  s.add_dependency('chef', '~> 11.0')
 end


### PR DESCRIPTION
chef-pedant runs knife, and expects specific output from it.  Systems without chef, or with old versions of it, fail the tests.
