### PR TITLE
Fix Issue #52 - Always pending tests

### DIFF
--- a/lib/pedant/rspec/auth_headers_util.rb
+++ b/lib/pedant/rspec/auth_headers_util.rb
@@ -286,7 +286,7 @@ module Pedant
 
         # X-Ops-Request-Source
         context 'when X-Ops-Request-Source is web' do
-          if (defined?(Pedant::Config.webui_key) != nil)
+          if Pedant::Config.webui_key
             # If no webui_key defined (i.e., in pushy pedant) skip
             # these tests
 


### PR DESCRIPTION
defined? does not evaluate expressions, so when an expressions is
passed to it that has no value until it is run, defined? will always
return nil. In this case, it was causing tests that should be run
in some cases to be marked as pending by the code.

This is intended to fix issue #52 

I've tested against the latest open source build (the latest beta for the coming release), but have not tested against a pushy build. 
