### PR TITLE
Add support for OPC reindexing

### DIFF
--- a/spec/api/osc_reindex_spec.rb
+++ b/spec/api/osc_reindex_spec.rb
@@ -1,0 +1,24 @@
+require 'pedant/rspec/data_bag_util'
+require 'pedant/rspec/role_util'
+require 'pedant/rspec/search_util'
+require 'pedant/rspec/node_util'
+require 'pedant/rspec/environment_util'
+require 'pedant/rspec/open_source_client_util'
+
+describe "Server-side reindexing" do
+  include Pedant::RSpec::DataBagUtil
+  include Pedant::RSpec::RoleUtil
+  include Pedant::RSpec::SearchUtil
+  include Pedant::RSpec::NodeUtil
+  include Pedant::RSpec::EnvironmentUtil
+
+  shared(:admin_requestor){admin_user}
+  shared(:requestor){admin_requestor}
+
+  context "reindexing", :platform => :open_source do
+    it_should_behave_like "Reindexing" do
+      let(:executable){"/opt/chef-server/embedded/service/erchef/bin/reindex-chef-server"}
+    end
+  end
+
+end


### PR DESCRIPTION
This adds or supports a 'reindex-opc-organization' escript that can
reindex all the data from a Private Chef organization in a single user
operation.  It is analogous to the existing 'reindex-chef-server'
script for Open Source Chef.

A private-chef-ctl 'reindex' command has been added, which provides
the UI for the tool.

Changes were made to underlying code that makes the reindexing
possible, which is why open-source repositories are involved.

Both OPC and OSC builds have passed through CI.

The OPC Omnibus branch requires OPC 11 features to run; support for
pre-Chef 11 OPC servers is not provided.

See all PRs for this work  in the following repositories:

   chef-pedant, chef_wm, erchef, oc-chef-pedant, oc_chef_wm, oc_erchef, opscode-omnibus
