### PR TITLE
this needs to be relaxed to 1.6.7

### DIFF
--- a/chef-pedant.gemspec
+++ b/chef-pedant.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.add_dependency('mixlib-authentication', '~> 1.3.0')
   s.add_dependency('mixlib-config', '~> 2.0')
   s.add_dependency('mixlib-shellout', '~> 1.1')
-  s.add_dependency('rest-client', '= 1.7.0.alpha')
+  s.add_dependency('rest-client', '>= 1.6.7')
   s.add_dependency('rspec_junit_formatter', '~> 0.1.1')
   s.add_dependency('net-http-spy', '~> 0.2.1')
   s.add_dependency('erubis', '~> 2.7.0')


### PR DESCRIPTION
actual chef-client has a restriction on rest-client <= 1.6.7

the ipv6 hacked up opscode/rest-client version has a branch
which lies about its version number and sets it to 1.6.7 so that
it can be loaded along with chef-client.

getting the ipv6 patches for rest-client accepted upstream would not
help now since 1.7.0 brings in rdoc which breaks our builds on solaris.
