### PR TITLE
mixlib-shellout 1.x or 2.x both work

### DIFF
--- a/chef-pedant.gemspec
+++ b/chef-pedant.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.add_dependency('activesupport', '~> 3.2.8') # For active_support/concern
   s.add_dependency('mixlib-authentication', '~> 1.3.0')
   s.add_dependency('mixlib-config', '~> 2.0')
-  s.add_dependency('mixlib-shellout', '~> 1.1')
+  s.add_dependency('mixlib-shellout', '>= 1.1')
   s.add_dependency('rest-client', '>= 1.6.7')
   s.add_dependency('rspec_junit_formatter', '~> 0.1.1')
   s.add_dependency('net-http-spy', '~> 0.2.1')


### PR DESCRIPTION
this needs to float and pick up whatever version chef picks up
