### PR TITLE
added controls to tags

### DIFF
--- a/lib/pedant/command_line.rb
+++ b/lib/pedant/command_line.rb
@@ -137,7 +137,7 @@ module Pedant
       tags = %w(environments cookbooks data_bags nodes roles sandboxes users
                 clients depsolver search knife validation authentication authorization
                 principals acl containers groups association omnibus organizations
-                usags internal_orgs rename_org)
+                usags internal_orgs rename_org controls)
       export_options(opts, tags)
     end
 


### PR DESCRIPTION
which allows --focus-controls/--skip-controls for `oc-chef-pedant`

See also: https://github.com/opscode/oc-chef-pedant/pull/85
