### PR TITLE
Upgrade to RSpec 3

### DIFF
--- a/chef-pedant.gemspec
+++ b/chef-pedant.gemspec
@@ -22,4 +22,6 @@ Gem::Specification.new do |s|
   s.add_dependency('net-http-spy', '~> 0.2.1')
   s.add_dependency('erubis', '~> 2.7.0')
   s.add_dependency('rspec-rerun', '= 0.1.1')
+  # RSpec ReRun needs this to work.
+  s.add_dependency('rspec-legacy_formatters', '~> 1.0')
 end

--- a/chef-pedant.gemspec
+++ b/chef-pedant.gemspec
@@ -12,13 +12,13 @@ Gem::Specification.new do |s|
   s.bindir        = 'bin'
   s.executables   = ['chef-pedant']
 
-  s.add_dependency('rspec', '~> 2.11')
+  s.add_dependency('rspec', '~> 3.1')
   s.add_dependency('activesupport', '~> 3.2.8') # For active_support/concern
   s.add_dependency('mixlib-authentication', '~> 1.3.0')
   s.add_dependency('mixlib-config', '~> 2.0')
   s.add_dependency('mixlib-shellout', '>= 1.1')
   s.add_dependency('rest-client', '>= 1.6.7')
-  s.add_dependency('rspec_junit_formatter', '~> 0.1.1')
+  s.add_dependency('rspec_junit_formatter', '~> 0.2.0')
   s.add_dependency('net-http-spy', '~> 0.2.1')
   s.add_dependency('erubis', '~> 2.7.0')
   s.add_dependency('rspec-rerun', '= 0.1.1')

--- a/lib/pedant.rb
+++ b/lib/pedant.rb
@@ -91,6 +91,14 @@ module Pedant
 
   def self.configure_rspec
     ::RSpec.configure do |c|
+      c.expect_with :rspec do |expectation|
+        expectation.syntax = [:should, :expect]
+      end
+
+      c.mock_with :rspec do |mock|
+        mock.syntax = [:should, :expect]
+      end
+
       c.treat_symbols_as_metadata_keys_with_true_values = true
 
       # If you just want to run one (or a few) tests in development,

--- a/lib/pedant.rb
+++ b/lib/pedant.rb
@@ -99,8 +99,6 @@ module Pedant
         mock.syntax = [:should, :expect]
       end
 
-      c.treat_symbols_as_metadata_keys_with_true_values = true
-
       # If you just want to run one (or a few) tests in development,
       # add :focus metadata
       c.filter_run :focus => true

--- a/lib/pedant/config.rb
+++ b/lib/pedant/config.rb
@@ -17,6 +17,8 @@ require 'mixlib/config'
 require 'pedant/command_line'
 require 'pedant/gem'
 
+# RSpec ReRun requires this until some version after 0.2.0
+require 'rspec/legacy_formatters'
 require 'rspec-rerun/formatters/failures_formatter'
 
 module Pedant

--- a/lib/pedant/rspec/auth_headers_util.rb
+++ b/lib/pedant/rspec/auth_headers_util.rb
@@ -125,6 +125,7 @@ module Pedant
         def self.with_modified_auth_headers(desc, expected_status, auth_header_options)
           context_options = auth_header_options[:focus] ? [:focus] : []
           context_options += auth_header_options[:pending] ? [:pending] : []
+          context_options += auth_header_options[:skip] ? [:skip] : []
           context_options << :validation if expected_status == 400
           context_options << :authentication if expected_status == 401
           context_options << :authorization if expected_status == 403

--- a/lib/pedant/rspec/auth_headers_util.rb
+++ b/lib/pedant/rspec/auth_headers_util.rb
@@ -154,10 +154,10 @@ module Pedant
 
           # X-Ops-Userid
           with_modified_auth_headers('missing X-Ops-Userid', 400, :user_id => nil,
-                                     :pending => true)
+                                     :skip => true)
           # an empty header should be treated as missing by the server
           with_modified_auth_headers('empty X-Ops-Userid', 400, :user_id => '',
-                                     :pending => true)
+                                     :skip => true)
           with_modified_auth_headers('nonexistent username in X-Ops-Userid', 401,
                                      :user_id => 'nowaythisexists')
           context "when X-Ops-Userid does not match signature", :authentication do
@@ -169,7 +169,7 @@ module Pedant
               response.should look_like({ :status => 401 })
             end
           end
-          with_modified_auth_headers('absolutely immense X-Ops-Userid', 401, :user_id => 'x'*2000, :pending => true)
+          with_modified_auth_headers('absolutely immense X-Ops-Userid', 401, :user_id => 'x'*2000, :skip => true)
 
           # X-Ops-Timestamp
           with_modified_auth_headers('missing X-Ops-Timestamp', 400, :timestamp => nil)
@@ -311,14 +311,14 @@ module Pedant
 
             context 'impersonating successful user' do
               it 'succeeds',
-                :pending => 'no webui_key defined in pedant config' do
+                :skip => 'no webui_key defined in pedant config' do
                 ;
               end
             end
 
             context 'impersonating failed user', :authentication do
               it 'fails',
-                :pending => 'no webui_key defined in pedant config' do
+                :skip => 'no webui_key defined in pedant config' do
                 ;
               end
             end
@@ -326,7 +326,7 @@ module Pedant
         end
 
         # X-Ops-Webkey-Tag
-        context 'X-Ops-Webkey-Tag', :pending => "Write X-Ops-Webkey-Tag tests" do
+        context 'X-Ops-Webkey-Tag', :skip => "Write X-Ops-Webkey-Tag tests" do
         end
 
         context "with other successful user" do

--- a/lib/pedant/rspec/common.rb
+++ b/lib/pedant/rspec/common.rb
@@ -457,7 +457,7 @@ module Pedant
 
         # If we're logging traffic, delimit the traffic from each test example
         if Pedant::Config.log_file
-          before :each do
+          before :each do |example|
             File.open(Pedant::Config.log_file, 'a') do |f1|
               f1.puts("<-<-<-<-<-<-<-<")
               f1.puts("BEGIN: " + example.description)
@@ -465,7 +465,7 @@ module Pedant
             end
           end
 
-          after :each do
+          after :each do |example|
             File.open(Pedant::Config.log_file, 'a') do |f1|
               f1.puts
               f1.puts("END: " + example.description)

--- a/lib/pedant/rspec/environment_util.rb
+++ b/lib/pedant/rspec/environment_util.rb
@@ -208,7 +208,7 @@ module Pedant
       def self.fails_with_value(variable, value, expected_error, existing_environment = nil,
                                 pending = false)
         if (pending)
-          it "with #{variable} = #{value} it reports 400", :validation, :pending do
+          it "with #{variable} = #{value} it reports 400", :validation, :skip do
           end
         else
           it "with #{variable} = #{value} it reports 400", :validation do
@@ -228,7 +228,7 @@ module Pedant
                                    existing_environment = nil, pending = false)
         expected_value ||= value
         if (pending)
-          it "with #{variable} = #{value} it succeeds", :pending do
+          it "with #{variable} = #{value} it succeeds", :skip do
           end
         else
           it "with #{variable} = #{value} it succeeds" do

--- a/lib/pedant/rspec/matchers.rb
+++ b/lib/pedant/rspec/matchers.rb
@@ -105,7 +105,7 @@ module RSpec
         end
       end
 
-      def failure_message_for_should
+      def failure_message
         """
 Expected a #{strict? ? "full" : "partial"} match of the result
 
@@ -119,7 +119,7 @@ to succeed, but it didn't!
 """
       end
 
-      def failure_message_for_should_not
+      def failure_message_when_negated
         """
 Expected a #{strict? ? "full" : "partial"} match of the result
 
@@ -158,7 +158,7 @@ RSpec::Matchers.define :have_status_code do |code|
     "respond with #{code} #{codes[code]}"
   end
 
-  failure_message_for_should do |response|
+  failure_message do |response|
     "Response should have HTTP status code #{code} ('#{codes[code]}'), but it was actually #{response.code} ('#{codes[response.code]}')"
   end
 end
@@ -184,7 +184,7 @@ RSpec::Matchers.define :have_error do |code, message|
     "respond with #{code} #{codes[code]} and an error message of '#{message}'"
   end
 
-  failure_message_for_should do |response|
+  failure_message do |response|
     <<-EOM
 1) HTTP status code should have been #{code} ('#{codes[code]}'); it was #{response.code}.
 
@@ -298,7 +298,7 @@ RSpec::Matchers.define :look_like do |expected_response_spec|
     "respond with #{code} #{Pedant::RSpec::HTTP::STATUS_CODES[code]}"
   end
 
-  failure_message_for_should do |response|
+  failure_message do |response|
     @error_message
   end
 end
@@ -336,7 +336,7 @@ RSpec::Matchers.define :have_outcome do |outcome_spec|
 
   # Could just spit out `executed_shellout_command.inspect`, but I
   # find the formatting suboptimal for testing error messages.
-  failure_message_for_should do |executed_shellout_command|
+  failure_message do |executed_shellout_command|
     "Executed command should have matched the outcome spec #{outcome_spec.inspect}, but it didn't!\n
 \tFailed Command: #{executed_shellout_command.command}\n
 \tCommand Setting: #{Pedant::Knife.command_setting(executed_shellout_command).inspect}\n

--- a/lib/pedant/rspec/matchers.rb
+++ b/lib/pedant/rspec/matchers.rb
@@ -230,7 +230,6 @@ RSpec::Matchers.define :look_like do |expected_response_spec|
 
   match do |response|
     begin
-      last_matcher, last_should = RSpec::Matchers.last_matcher, RSpec::Matchers.last_should
       things_to_check = expected_response_spec.keys
       json_tests = [:body, :body_exact]
 
@@ -286,9 +285,6 @@ RSpec::Matchers.define :look_like do |expected_response_spec|
         end
       end
 
-      # if we get down here without throwing an exception, we pass!
-      # Reset last matchers and should to this one
-      RSpec::Matchers.last_matcher, RSpec::Matchers.last_should = last_matcher, last_should
       true
     rescue RSpec::Expectations::ExpectationNotMetError => e
       @error_message = e.message

--- a/spec/api/environments/create_spec.rb
+++ b/spec/api/environments/create_spec.rb
@@ -168,7 +168,7 @@ describe "Environments API Endpoint", :environments do
             fails_with_value("name", "abc\u0000123",
                              "Field 'name' invalid")
           else
-            context 'ejson:decode eats nulls', :pending do
+            context 'ejson:decode eats nulls', :skip do
               fails_with_value("name", "abc\u0000123",
                                "Field 'name' invalid")
             end

--- a/spec/api/environments/update_spec.rb
+++ b/spec/api/environments/update_spec.rb
@@ -180,7 +180,7 @@ describe "Environments API Endpoint", :environments do
             fails_with_value("name", "abc\u0000123",
                              "Field 'name' invalid", true)
           else
-            context 'ejson:decode eats nulls', :pending do
+            context 'ejson:decode eats nulls', :skip do
               fails_with_value("name", "abc\u0000123",
                                "Field 'name' invalid", true)
             end

--- a/spec/api/knife/cookbook/download_spec.rb
+++ b/spec/api/knife/cookbook/download_spec.rb
@@ -16,7 +16,7 @@
 require 'pedant/rspec/knife_util'
 require 'pedant/rspec/cookbook_util'
 
-describe 'knife', knife: true, pending: !open_source? do
+describe 'knife', knife: true, skip: !open_source? do
   context 'cookbook' do
     context 'download' do
       include Pedant::RSpec::KnifeUtil

--- a/spec/api/knife/cookbook/upload_spec.rb
+++ b/spec/api/knife/cookbook/upload_spec.rb
@@ -16,7 +16,7 @@
 require 'pedant/rspec/knife_util'
 
 
-describe 'knife', knife: true, pending: !open_source? do
+describe 'knife', knife: true, skip: !open_source? do
   context 'cookbook' do
     context 'upload' do
       include Pedant::RSpec::KnifeUtil

--- a/spec/api/knife/data_bag/create_spec.rb
+++ b/spec/api/knife/data_bag/create_spec.rb
@@ -15,7 +15,7 @@
 
 require 'pedant/rspec/knife_util'
 
-describe 'knife', knife: true, pending: !open_source? do
+describe 'knife', knife: true, skip: !open_source? do
   context 'data bag' do
     context 'create' do
       include Pedant::RSpec::KnifeUtil

--- a/spec/api/knife/data_bag/delete_spec.rb
+++ b/spec/api/knife/data_bag/delete_spec.rb
@@ -15,7 +15,7 @@
 
 require 'pedant/rspec/knife_util'
 
-describe 'knife', knife: true, pending: !open_source? do
+describe 'knife', knife: true, skip: !open_source? do
   context 'data bag' do
     context 'delete' do
       include Pedant::RSpec::KnifeUtil

--- a/spec/api/knife/data_bag/from_file_spec.rb
+++ b/spec/api/knife/data_bag/from_file_spec.rb
@@ -16,7 +16,7 @@
 require 'pedant/rspec/knife_util'
 require 'securerandom'
 
-describe 'knife', knife: true, pending: !open_source? do
+describe 'knife', knife: true, skip: !open_source? do
   context 'data bag' do
     context 'from file' do
       include Pedant::RSpec::KnifeUtil

--- a/spec/api/knife/data_bag/list_spec.rb
+++ b/spec/api/knife/data_bag/list_spec.rb
@@ -16,7 +16,7 @@
 require 'pedant/rspec/knife_util'
 require 'securerandom'
 
-describe 'knife', knife: true, pending: !open_source? do
+describe 'knife', knife: true, skip: !open_source? do
   context 'data bag' do
     context 'show [ITEM]' do
       include Pedant::RSpec::KnifeUtil

--- a/spec/api/knife/data_bag/show_spec.rb
+++ b/spec/api/knife/data_bag/show_spec.rb
@@ -16,7 +16,7 @@
 require 'pedant/rspec/knife_util'
 require 'securerandom'
 
-describe 'knife', knife: true, pending: !open_source? do
+describe 'knife', knife: true, skip: !open_source? do
   context 'data bag' do
     context 'show [ITEM]' do
       include Pedant::RSpec::KnifeUtil

--- a/spec/api/knife/nodes/bulk_delete_spec.rb
+++ b/spec/api/knife/nodes/bulk_delete_spec.rb
@@ -16,7 +16,7 @@
 require 'pedant/rspec/knife_util'
 require 'securerandom'
 
-describe 'knife', knife: true, pending: !open_source? do
+describe 'knife', knife: true, skip: !open_source? do
   context 'node' do
     context 'bulk delete REGEX' do
       include Pedant::RSpec::KnifeUtil

--- a/spec/api/knife/nodes/create_spec.rb
+++ b/spec/api/knife/nodes/create_spec.rb
@@ -15,7 +15,7 @@
 
 require 'pedant/rspec/knife_util'
 
-describe 'knife', knife: true, pending: !open_source? do
+describe 'knife', knife: true, skip: !open_source? do
   context 'node' do
     context 'create' do
       include Pedant::RSpec::KnifeUtil
@@ -39,14 +39,13 @@ describe 'knife', knife: true, pending: !open_source? do
           let(:requestor) { knife_admin }
 
           it 'should fail' do
-            pending 'CHEF-982: `knife node create` does not report name conflicts' do
-              # Create a node with the same name
-              #knife "node create #{node_name} -c #{knife_config} --disable-editing"
-              post(api_url("/nodes"), platform.admin_user, payload: { "name" => node_name })
+            pending 'CHEF-982: `knife node create` does not report name conflicts'
+            # Create a node with the same name
+            #knife "node create #{node_name} -c #{knife_config} --disable-editing"
+            post(api_url("/nodes"), platform.admin_user, payload: { "name" => node_name })
 
-              # Run knife a second time
-              should have_outcome :status => 0, :stdout => /Node #{node_name} already exists/
-            end
+            # Run knife a second time
+            should have_outcome :status => 0, :stdout => /Node #{node_name} already exists/
           end
         end
       end

--- a/spec/api/knife/nodes/delete_spec.rb
+++ b/spec/api/knife/nodes/delete_spec.rb
@@ -15,7 +15,7 @@
 
 require 'pedant/rspec/knife_util'
 
-describe 'knife', knife: true, pending: !open_source? do
+describe 'knife', knife: true, skip: !open_source? do
   context 'node' do
     context 'delete' do
       include Pedant::RSpec::KnifeUtil

--- a/spec/api/knife/nodes/from_file_spec.rb
+++ b/spec/api/knife/nodes/from_file_spec.rb
@@ -16,9 +16,9 @@
 require 'pedant/rspec/knife_util'
 require 'securerandom'
 
-describe 'knife', knife: true, pending: !open_source? do
+describe 'knife', knife: true, skip: !open_source? do
   context 'node' do
-    context 'from file NODE', pending: "OC-3957: Write specs for `knife node from file`" do
+    context 'from file NODE', skip: "OC-3957: Write specs for `knife node from file`" do
       include Pedant::RSpec::KnifeUtil
       include Pedant::RSpec::KnifeUtil::Node
 
@@ -29,7 +29,7 @@ describe 'knife', knife: true, pending: !open_source? do
         context 'as an admin' do
           let(:requestor) { knife_admin }
 
-          it 'should succeed' do #, pending: "ERROR: Method not allowed when using node from file?" do
+          it 'should succeed' do #, skip: "ERROR: Method not allowed when using node from file?" do
             assume_fixture_file!
 
             # Runs knife node from file

--- a/spec/api/knife/nodes/list_spec.rb
+++ b/spec/api/knife/nodes/list_spec.rb
@@ -16,7 +16,7 @@
 require 'pedant/rspec/knife_util'
 require 'securerandom'
 
-describe 'knife', knife: true, pending: !open_source? do
+describe 'knife', knife: true, skip: !open_source? do
   context 'node' do
     context 'list' do
       include Pedant::RSpec::KnifeUtil

--- a/spec/api/knife/nodes/run_list_spec.rb
+++ b/spec/api/knife/nodes/run_list_spec.rb
@@ -16,7 +16,7 @@
 require 'pedant/rspec/knife_util'
 require 'securerandom'
 
-describe 'knife', knife: true, pending: !open_source? do
+describe 'knife', knife: true, skip: !open_source? do
   context 'node' do
     context 'run_list' do
       include Pedant::RSpec::KnifeUtil

--- a/spec/api/knife/nodes/show_spec.rb
+++ b/spec/api/knife/nodes/show_spec.rb
@@ -39,7 +39,7 @@ describe 'knife', knife: true, skip: !open_source? do
         context 'as an admin' do
           let(:requestor) { knife_admin }
 
-          it 'should succeed' do #, pending: "ERROR: Method not allowed when using node from file?" do
+          it 'should succeed' do #, skip: "ERROR: Method not allowed when using node from file?" do
             assume_existing_node!
 
             # Runs knife node from file

--- a/spec/api/knife/nodes/show_spec.rb
+++ b/spec/api/knife/nodes/show_spec.rb
@@ -16,7 +16,7 @@
 require 'pedant/rspec/knife_util'
 require 'securerandom'
 
-describe 'knife', knife: true, pending: !open_source? do
+describe 'knife', knife: true, skip: !open_source? do
   context 'node' do
     context 'show [NODE]' do
       include Pedant::RSpec::KnifeUtil

--- a/spec/api/knife/roles/bulk_delete_spec.rb
+++ b/spec/api/knife/roles/bulk_delete_spec.rb
@@ -21,7 +21,7 @@ require 'securerandom'
 # method
 require 'pedant/rspec/search_util'
 
-describe 'knife', knife: true, pending: !open_source? do
+describe 'knife', knife: true, skip: !open_source? do
   context 'role' do
     context 'bulk delete REGEX' do
       include Pedant::RSpec::KnifeUtil

--- a/spec/api/knife/roles/create_spec.rb
+++ b/spec/api/knife/roles/create_spec.rb
@@ -15,7 +15,7 @@
 
 require 'pedant/rspec/knife_util'
 
-describe 'knife', knife: true, pending: !open_source? do
+describe 'knife', knife: true, skip: !open_source? do
   context 'role' do
     context 'create [ROLE]' do
       include Pedant::RSpec::KnifeUtil
@@ -39,14 +39,13 @@ describe 'knife', knife: true, pending: !open_source? do
           let(:requestor) { knife_admin }
 
           it 'should fail' do
-            pending 'CHEF-982: `knife role create` does not report name conflicts' do
-              # Create a role with the same name
-              #knife "role create #{role_name} -c #{knife_config} --disable-editing"
-              post(api_url("/roles"), platform.admin_user, payload: { "name" => role_name })
+            skip 'CHEF-982: `knife role create` does not report name conflicts'
+            # Create a role with the same name
+            #knife "role create #{role_name} -c #{knife_config} --disable-editing"
+            post(api_url("/roles"), platform.admin_user, payload: { "name" => role_name })
 
-              # Run knife a second time
-              should have_outcome :status => 0, :stdout => /Node #{role_name} already exists/
-            end
+            # Run knife a second time
+            should have_outcome :status => 0, :stdout => /Node #{role_name} already exists/
           end
         end
       end

--- a/spec/api/knife/roles/delete_spec.rb
+++ b/spec/api/knife/roles/delete_spec.rb
@@ -15,7 +15,7 @@
 
 require 'pedant/rspec/knife_util'
 
-describe 'knife', knife: true, pending: !open_source? do
+describe 'knife', knife: true, skip: !open_source? do
   context 'role' do
     context 'delete [ROLE]' do
       include Pedant::RSpec::KnifeUtil

--- a/spec/api/knife/roles/from_file_spec.rb
+++ b/spec/api/knife/roles/from_file_spec.rb
@@ -16,7 +16,7 @@
 require 'pedant/rspec/knife_util'
 require 'securerandom'
 
-describe 'knife', knife: true, pending: !open_source? do
+describe 'knife', knife: true, skip: !open_source? do
   context 'role' do
     context 'from file ROLE' do
       include Pedant::RSpec::KnifeUtil

--- a/spec/api/knife/roles/list_spec.rb
+++ b/spec/api/knife/roles/list_spec.rb
@@ -16,7 +16,7 @@
 require 'pedant/rspec/knife_util'
 require 'securerandom'
 
-describe 'knife', knife: true, pending: !open_source? do
+describe 'knife', knife: true, skip: !open_source? do
   context 'role' do
     context 'list' do
       include Pedant::RSpec::KnifeUtil

--- a/spec/api/knife/roles/show_spec.rb
+++ b/spec/api/knife/roles/show_spec.rb
@@ -16,7 +16,7 @@
 require 'pedant/rspec/knife_util'
 require 'securerandom'
 
-describe 'knife', knife: true, pending: !open_source? do
+describe 'knife', knife: true, skip: !open_source? do
   context 'role' do
     context 'show [ROLE]' do
       include Pedant::RSpec::KnifeUtil

--- a/spec/api/users_spec.rb
+++ b/spec/api/users_spec.rb
@@ -414,8 +414,8 @@ describe "Open Source /users endpoint", :users => true, :platform => :open_sourc
         # if it succeeds in deleting the user (it shouldn't) other tests could fail
         # Note that this test will fail if other admin users exist on the system for some reason
         # ensure the only other admin in the system doesn't exist
-        # BUG: Marked as pending: admin clients can turn off the last user admin
-        context 'when turning off admin for last admin', pending: "CHEF-3658: admin clients should not be able to de-admin admin user", smoke: false do
+        # BUG: Marked as skip: admin clients can turn off the last user admin
+        context 'when turning off admin for last admin', skip: "CHEF-3658: admin clients should not be able to de-admin admin user", smoke: false do
           before(:each) { delete_user(test_user) }
 
           let(:expected_response) { forbidden_response }


### PR DESCRIPTION
Upgrade Chef Pedant to RSpec 3. This will likely require corresponding changes in oc-chef-pedant, which I'll investigate next. I need this change in order to update Chef Zero's development dependencies to a newer version of Chef, which I in turn need in order to get Chef Zero to take advantage of new features added to ChefFS (which is used when Chef Zero is configured to use disk-based storage).

@chef/server-team @jkeiser 