### PR TITLE
Rspec 3.2

### DIFF
--- a/lib/pedant/command_line.rb
+++ b/lib/pedant/command_line.rb
@@ -137,7 +137,7 @@ module Pedant
       tags = %w(environments cookbooks data_bags nodes roles sandboxes users
                 clients depsolver search knife validation authentication authorization
                 principals acl containers groups association omnibus organizations
-                usags internal_orgs rename_org controls keys)
+                usags internal_orgs rename_org controls keys cookbook_artifacts)
       export_options(opts, tags)
     end
 

--- a/lib/pedant/rspec/common.rb
+++ b/lib/pedant/rspec/common.rb
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require 'rspec-shared/methods'
+
 require 'pedant/concern'
 require 'pedant/json'
 require 'pedant/request'
@@ -27,11 +29,15 @@ end
 module Pedant
   module RSpec
     module Common
+
       extend Pedant::Concern
       # We use a concern instead of a shared context in order to access
       # the complete Rspec DSL, plus extensions (metadata, shared(), etc.)
 
-      included do
+      included do |base|
+
+        base.extend(RSpecShared::Methods)
+
         include Pedant::JSON
         include Pedant::Request
         include Pedant::RSpec::CommonResponses


### PR DESCRIPTION
Fixes Pedant for changes in RSpec 3.2. Since Chef requires 3.2 (for audit mode), pedant needs to work w/ 3.2 in order to test chef-zero (which is broken on master right now).

@chef/server-team 